### PR TITLE
Fix: Correct placeholder in smartEscapeMarkdown

### DIFF
--- a/commands/summary.js
+++ b/commands/summary.js
@@ -372,7 +372,7 @@ function smartEscapeMarkdown(text) {
     // 对标题内部的下划线进行转义，保持星号不变
     const escapedTitle = match.replace(/_/g, '\\_');
     titles.push(escapedTitle);
-    return `__TITLE_PLACEHOLDER_${titleIndex++}__`;
+    return `%%TITLE_PLACEHOLDER_${titleIndex++}%%`;
   });
 
   // 转义非标题部分的特殊字符
@@ -386,7 +386,7 @@ function smartEscapeMarkdown(text) {
   // 恢复标题格式
   let finalText = escapedText;
   titles.forEach((title, index) => {
-    finalText = finalText.replace(`__TITLE_PLACEHOLDER_${index}__`, title);
+    finalText = finalText.replace(`%%TITLE_PLACEHOLDER_${index}%%`, title);
   });
 
   return finalText;


### PR DESCRIPTION
commands/summary.js 文件中的 smartEscapeMarkdown 函数曾使用一个包含下划线的占位符 __TITLE_PLACEHOLDER_${index}__。问题在于，该函数自身的逻辑会转义这些下划线，从而破坏占位符的结构，并导致标题无法被正确恢复。

本次提交将占位符更改为 %%TITLE_PLACEHOLDER_${index}%%，新占位符所使用的字符不会被该函数转义。这确保了占位符在整个转义过程中保持完整，从而修复了这个错误，并避免了生成格式错误的 Markdown 输出。